### PR TITLE
Remove Codango as it isn't working

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | Name | Description | Link |
 |------|-------------|------|
 | [Shoop](https://github.com/shoopio/shoop) | E-commerce Platform | [https://shoop.io](https://shoop.io) |
-| [Codango](https://github.com/andela/codango) | Social Network for Coders | |
 | [Django-CMS](https://github.com/divio/django-cms) | Easy to use and developer friendly CMS | [http://www.django-cms.org](http://www.django-cms.org) |
 | [Django-fiber](https://github.com/ridethepony/django-fiber) | A simple, user-friendly CMS for all your Django projects | [http://ridethepony.org](http://ridethepony.org) |
 | [Feincms](https://github.com/feincms/feincms) | A Django-based CMS with a focus on extensibility and concise code | [http://www.feincms.org](http://www.feincms.org) |


### PR DESCRIPTION
As codango lands us to the page which throws error 404, I thought we should remove it from the list.