### PR TITLE
Remove 92five as it is not FLOSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | [Airflix](https://github.com/wells/airflix) | A near-netflix Clone  | |
 | [Antvel](https://github.com/ant-vel/App) | Laravel eCommerce | [http://antvel.com](http://antvel.com) |
 | [LaraShop](https://github.com/ZENLIX/LaraShop) | A Simple PHP Shop CMS | [http://it-toys.com](http://it-toys.com) |
-| [92five](https://github.com/chintanbanugaria/92five) | Self-hosted Project Management App | [http://92fiveapp.com](http://92fiveapp.com) |
 | [Deployer](https://github.com/REBELinBLUE/deployer) | A free and open source deployment tool | [http://phpdeployment.org](http://phpdeployment.org) |
 | [Paperwork](https://github.com/twostairs/paperwork) | OpenSource note-taking & archiving alternative to Evernote, Microsoft OneNote & Google Keep | [http://paperwork.rocks](http://paperwork.rocks) |
 | [Podcastwala](https://github.com/modestkdr/Podcastwala) | Podcast System | |


### PR DESCRIPTION
The project 92five is released under CC-BY-ND which is not an approved by neither FSF nor OSI as a FLOSS license. It is not Open Source since it violates the right to modify the code (NoDerivatives).