### PR TITLE
Remove Statamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | [Laravel.com](https://github.com/laravel/laravel.com) | Official Website and Documentation of Laravel | [https://laravel.com](https://laravel.com) |
 | [Katana](https://github.com/themsaid/katana) | Laravel static site/blog generator with markdown support |  |
 | [CoasterCMS](https://github.com/web-feet/coastercms) | Coaster CMS Project | [http://www.coastercms.org](http://www.coastercms.org) |
-| [Statamic](https://github.com/statamic) | Flat File CMS | [https://statamic.com](https://statamic.com) |
 | [Larasocial](https://github.com/msalom28/Larasocial) | A Social Network Application | [http://larasocial.info](http://larasocial.info) |
 | [Aimeos](https://github.com/aimeos/aimeos-laravel) | Ecommerce package for high performance online shops | [https://aimeos.org/Laravel](https://aimeos.org/Laravel) |
 | [Gitamin](https://github.com/GitaminHQ/Gitamin) | A self-hosted git repository management software | [http://gitamin.com](http://gitamin.com) |


### PR DESCRIPTION
Statamic doens't have any approved FLOSS license. The license provided [here](https://github.com/statamic/cms/blob/3.1/LICENSE.md) violates both Free Software and Open Source definitions.