### PR TITLE
Added Materio Free Vuetify VueJS Laravel Admin Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | [Unifiedtransform](https://github.com/changeweb/Unifiedtransform) |  A School Management Software. | [https://changeweb.github.io/Unifiedtransform/](https://changeweb.github.io/Unifiedtransform/) | |
 | [Tinre](https://github.com/devpri/tinre) |  A fast and powerful URL Shortener built with Laravel, VueJS, and Tailwind CSS. | [https://github.com/devpri/tinre](https://github.com/devpri/tinre) | |
 | [Taskord](https://gitlab.com/taskord/taskord) |  Get things done socially with community of makers. | [https://taskord.com](https://taskord.com) | |
+| [Materio  Free Vuetify VueJS Laravel Admin Template](https://github.com/themeselection/materio-vuetify-vuejs-laravel-admin-template-free) |  Open-source & easy to use Vuetify Vuejs Laravel Admin Template with Elegant Design & Unique Layout. | [https://themeselection.com/](https://themeselection.com/) | |
+
 
 ## Rails
 


### PR DESCRIPTION
### Materio Free Vuetify VueJS Laravel Admin Template.

It is open-source & easy to use Vuetify Vuejs Laravel Admin Template with Elegant Design & Unique Layout.

**Features:**

- Build with VueJS + Laravel
- Utilizes Vuex, Vue Router, Webpack
- 1 Dashboard
- Material Icons
- Basic cards
- Fully Responsive Layout
- Organized Folder Structure
- Clean & Commented Code

For More Info: https://themeselection.com/products/materio-free-vuetify-vuejs-laravel-admin-template/
GitHub repo: https://github.com/themeselection/materio-vuetify-vuejs-laravel-admin-template-free
Demo: https://themeselection.com/demo/materio-vuetify-vuejs-laravel-admin-template-free/demo/dashboard