### PR TITLE
Add What Broke Today to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) | Django based document management system with OCR, indexing, full text searching, previewing and more | [https://www.mayan-edms.com/](https://www.mayan-edms.com/) |
 | [Django-shop](https://github.com/awesto/django-shop) | A Django based shop system | [https://django-shop.readthedocs.io/en/latest/index.html](https://django-shop.readthedocs.io/en/latest/index.html)|
 | [Django Project](https://www.djangoproject.com/) | Official Django Website and Documentation | [https://www.djangoproject.com/](https://www.djangoproject.com/)|
+| [What Broke Today](https://github.com/reshadat/whatbroketoday) | AI-powered outage aggregator built with FastAPI/Python tracking 100+ cloud services with Telegram alerts, RSS feed, and JSON API | [https://whatbroke.today](https://whatbroke.today) |
 | [Travel Mate Server](https://github.com/project-travel-mate/server) | Django based document management system with OCR, indexing, full text searching, previewing and more | [App on PlayStore](https://goo.gl/1iAq94) |
 
 


### PR DESCRIPTION
## Summary

Adding [What Broke Today](https://whatbroke.today/) to the Python/Django section.

**What Broke Today** is an open-source application built with Python/FastAPI that:
- Monitors 100+ cloud services (AWS, Azure, GCP, GitHub, Cloudflare, etc.)
- Uses AI to filter and summarize service outages
- Provides real-time Telegram alerts
- Offers RSS feed and JSON API

**Website**: https://whatbroke.today
**Source Code**: https://github.com/reshadat/whatbroketoday
**Tech Stack**: FastAPI, SQLite, Jinja2, Python