### PR TITLE
Add Unpod - Open-source AI voice agent platform (Node.js)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,4 +293,4 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | Name | Description | Link |
 |------|-------------|------|
 | [ShotOG](https://github.com/nicepkg/shotog) | Open-source OG image generation API with 8 templates, batch generation, and custom fonts. Built with Hono + Satori on Cloudflare Workers. | [https://shotog.2214962083.workers.dev](https://shotog.2214962083.workers.dev) |
-| [Unpod](https://github.com/parvbhullar/unpod) | Open-source platform for building AI voice agents with dedicated phone numbers. Visual studio to create agents that handle calls and messages across channels. Built with Next.js, Django, LiveKit, and Pipecat. | [https://unpod.ai](https://unpod.ai) |
+| [Unpod](https://unpod.ai) | Open-source platform for building AI voice agents with dedicated phone numbers. Visual studio to create agents that handle calls and messages across channels. Built with Next.js, Django, LiveKit, and Pipecat. | [unpod.ai](https://unpod.ai) \| [GitHub](https://github.com/parvbhullar/unpod) |


### PR DESCRIPTION
Added [Unpod](https://github.com/parvbhullar/unpod) to the Node.js section.

Unpod is an open-source platform for building conversational AI voice agents — you assign agents to real phone numbers and they handle inbound calls and messages through a visual no-code studio. It's like a WordPress for voice AI.

Stack: Next.js 16, React 19, Django 5, FastAPI, LiveKit, Pipecat, LangChain, PostgreSQL, Redis, Kafka.

GitHub: https://github.com/parvbhullar/unpod