### PR TITLE
Add unpod

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,4 +293,4 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | Name | Description | Link |
 |------|-------------|------|
 | [ShotOG](https://github.com/nicepkg/shotog) | Open-source OG image generation API with 8 templates, batch generation, and custom fonts. Built with Hono + Satori on Cloudflare Workers. | [https://shotog.2214962083.workers.dev](https://shotog.2214962083.workers.dev) |
- [Unpod](https://github.com/parvbhullar/unpod) – Open-source Voice AI platform that helps developers build, manage, and deploy real-time AI voice agents. Supports streaming LLM responses, WebSocket-based APIs, multi-model integrations, and voice capabilities (STT/TTS) — making it easy to create production-ready conversational AI applications.
+| [Unpod](https://github.com/parvbhullar/unpod) |  Open-source Voice AI platform that helps developers build, manage, and deploy real-time AI voice agents. Supports streaming LLM responses, WebSocket-based APIs, multi-model integrations, and voice capabilities (STT/TTS) — making it easy to create production-ready conversational AI applications.


### PR DESCRIPTION
Hey Developers
Added Unpod to the Platforms & Tools section.

Unpod is a Voice AI infrastructure platform designed to power AI-native phone and messaging agents. It handles real-time telephony orchestration, streaming speech pipelines, and production-grade call workflows effectively serving as the infrastructure layer between carrier-level protocols (SIP/RTP) and LLM-driven conversational logic.

Positioned alongside Vapi and Retell AI in the commercial Voice AI platforms category.