### PR TITLE
Add Lockpaw to Swift section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 - [C++](#cpp)
 - [Lua](#lua)
 - [Node.js](#nodejs)
+- [Swift](#swift)
 
 
 ## Laravel
@@ -293,3 +294,8 @@ Even if you are just a developer, manager or co-founder looking for a sample app
 | Name | Description | Link |
 |------|-------------|------|
 | [ShotOG](https://github.com/nicepkg/shotog) | Open-source OG image generation API with 8 templates, batch generation, and custom fonts. Built with Hono + Satori on Cloudflare Workers. | [https://shotog.2214962083.workers.dev](https://shotog.2214962083.workers.dev) |
+
+## Swift
+| Name | Description | Link |
+|------|-------------|------|
+| [Lockpaw](https://github.com/sorkila/lockpaw) | macOS menu bar screen guard — cover your screen while AI agents keep running. Lock/unlock with a hotkey. | [https://getlockpaw.com](https://getlockpaw.com) |


### PR DESCRIPTION
## Summary

- Adds new **Swift** section to the Table of Contents and README
- Adds [Lockpaw](https://github.com/sorkila/lockpaw) — an open-source (MIT) macOS menu bar screen guard built with Swift/SwiftUI

**Note:** This PR is based on commit `17b4044` (the last commit before PR #149 inadvertently overwrote the README with unrelated content). Other open PRs (#131–#148) are also based on this version.

## About Lockpaw

- macOS menu bar app to lock/unlock your screen with a global hotkey
- Built with Swift/SwiftUI, requires macOS 14+
- 79+ GitHub stars, MIT license
- Homepage: [getlockpaw.com](https://getlockpaw.com)